### PR TITLE
Some fixes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use_flake
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _build
 result
 
 *.mligo
+*.jsligo
 *.tz
 *.wat
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ result
 *.mligo
 *.tz
 *.wat
+
+.direnv

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -4,12 +4,11 @@ open Piaf
 let request_handler ~env =
   let router = Ligo_deku_rpc.Router.router ~env () in
   fun req ->
-  let { Server.ctx = _; request } = req in
-  Logs.debug (fun m -> m "Request to %s" request.target);
-  Routes.match' router  ~target:request.target
-  |> function
-  | Routes.NoMatch -> Piaf.Response.create `Not_found
-  | FullMatch handler | MatchWithTrailingSlash handler -> handler req
+    let { Server.ctx = _; request } = req in
+    Logs.debug (fun m -> m "Request to %s" request.target);
+    Routes.match' router ~target:request.target |> function
+    | Routes.NoMatch -> Piaf.Response.create `Not_found
+    | FullMatch handler | MatchWithTrailingSlash handler -> handler req
 
 let main port =
   let config = Server.Config.create port in
@@ -30,8 +29,8 @@ let setup_log ?style_renderer level =
 
 let () =
   setup_log Logs.Info;
-  let port = ref 8080 in
+  let port = ref 9090 in
   Arg.parse
-    [ ("-p", Arg.Set_int port, " Listening port number (8080 by default)") ]
+    [ ("-p", Arg.Set_int port, " Listening port number (9090 by default)") ]
     ignore "Echoes POST requests. Runs forever.";
   main !port

--- a/src/lib/hash.ml
+++ b/src/lib/hash.ml
@@ -1,5 +1,9 @@
+let alphabet =
+  Base64.make_alphabet
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+_"
+
 let make content =
   let content = Cstruct.of_string content in
   Mirage_crypto.Hash.MD5.digest content
   |> Cstruct.to_string
-  |> Base64.encode_string ~pad:false ~alphabet:Base64.uri_safe_alphabet
+  |> Base64.encode_string ~pad:false ~alphabet

--- a/src/lib/router.ml
+++ b/src/lib/router.ml
@@ -2,12 +2,12 @@ open Piaf
 
 let ligo_to_tz ~env ~hash ~lang () =
   Eio.Switch.run @@ fun sw ->
-  let filename_mligo = Printf.sprintf "%s.mligo" hash in
+  let filename_ligo = Printf.sprintf "%s.%s" hash lang in
   let filename_tz = Printf.sprintf "%s.tz" hash in
-  Logs.info (fun m -> m "compiling %s with syntax %s" filename_mligo lang);
+  Logs.info (fun m -> m "compiling %s with syntax %s" filename_ligo lang);
   let stdout =
     Unix.open_process_args_in "ligo"
-      [| "ligo"; "compile"; "contract"; "--syntax"; lang; filename_mligo |]
+      [| "ligo"; "compile"; "contract"; "--syntax"; lang; filename_ligo |]
   in
   let descr = Unix.descr_of_in_channel stdout in
   let source =
@@ -64,19 +64,19 @@ let to_wasm ~env () =
     in
 
     let hash = Hash.make source in
-    let filename_mligo = Printf.sprintf "%s.mligo" hash in
+    let filename_ligo = Printf.sprintf "%s.%s" hash lang in
     let filename_tz = Printf.sprintf "%s.tz" hash in
     let filename_wasm = Printf.sprintf "%s.wat" hash in
-    let mligo_path = Eio.Path.(Eio.Stdenv.cwd env / filename_mligo) in
-    let tz_path = Eio.Path.(Eio.Stdenv.cwd env / filename_tz) in
+    let ligo_path = Eio.Path.(Eio.Stdenv.cwd env / filename_ligo) in
     let wasm_path = Eio.Path.(Eio.Stdenv.cwd env / filename_wasm) in
+    let tz_path = Eio.Path.(Eio.Stdenv.cwd env / filename_tz) in
     let data = try Some (Eio.Path.load tz_path) with _ -> None in
 
     let wasm =
       match data with
       | None ->
           let () =
-            try Eio.Path.save ~create:(`Exclusive 0o600) mligo_path source
+            try Eio.Path.save ~create:(`Exclusive 0o600) ligo_path source
             with _ -> ()
           in
           let () = ligo_to_tz ~env ~hash ~lang () in

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+dune build || exit 1
+
+_build/install/default/bin/ligo_deku_rpc


### PR DESCRIPTION
I had some bugs when using the ligo-deku-rpc on my machine:

-  I generated a contract with an hash starting by the char '-', so the filename was considered as an argument 
   Solution: changing the base64 alphabet used to generate the filename

- I found an interesting bug, you can't originate two contract with the same code but a different storage, because the wasm file is never deleted (I guess it's not deleted to have a kind of cache).
 Solution: just delete the wasm file. So only the tz to wasm function is call when you want to originate an already known contract

- Not a bug, but I added an .envrc and a start script

- Not a bug: I've made a small factorization of the different path

- Not a bug: I've set the default port to 9090, because the deku-api is running by default on port 8080 and I am running both of them
