### PR TITLE
fix exposed port in docker.nix following refactoring done

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -24,12 +24,12 @@ nix2containerPkgs.nix2container.buildImage rec {
 
   config = {
     Entrypoint = ["${ligo-deku-rpc}/bin/ligo-deku-rpc"];
-    Cmd = ["-p" "8080"];
+    Cmd = ["-p" "9090"];
     author = "Ulrik Strid";
     architecture = "amd64";
     os = "linux";
     ExposedPorts = {
-      "8080/tcp" = {};
+      "9090/tcp" = {};
     };
 
     Env = [


### PR DESCRIPTION
https://github.com/marigold-dev/ligo-deku-rpc/commit/41fb3553b66c99fa6914c778ca5acd5bb60896d4 
is not complete, we want the modification to make it work on k8s